### PR TITLE
Add unicode support (TrieNode and Text importer)

### DIFF
--- a/spec/loophp/phptree/Importer/MicrosoftTolerantPhpParserSpec.php
+++ b/spec/loophp/phptree/Importer/MicrosoftTolerantPhpParserSpec.php
@@ -30,7 +30,7 @@ class MicrosoftTolerantPhpParserSpec extends ObjectBehavior
         $this
             ->import($ast)
             ->count()
-            ->shouldReturn(598);
+            ->shouldReturn(634);
 
         $file = __DIR__ . '/../../../../tests/sample.php';
 
@@ -39,7 +39,7 @@ class MicrosoftTolerantPhpParserSpec extends ObjectBehavior
         $this
             ->import($ast)
             ->count()
-            ->shouldReturn(117);
+            ->shouldReturn(114);
     }
 
     public function it_is_initializable(): void

--- a/spec/loophp/phptree/Importer/NikicPhpAstSpec.php
+++ b/spec/loophp/phptree/Importer/NikicPhpAstSpec.php
@@ -27,7 +27,7 @@ class NikicPhpAstSpec extends ObjectBehavior
         $this
             ->import($ast)
             ->count()
-            ->shouldReturn(551);
+            ->shouldReturn(542);
 
         $file = __DIR__ . '/../../../../tests/sample.php';
         $ast = \ast\parse_file($file, 50);
@@ -35,7 +35,7 @@ class NikicPhpAstSpec extends ObjectBehavior
         $this
             ->import($ast)
             ->count()
-            ->shouldReturn(87);
+            ->shouldReturn(85);
     }
 
     public function it_is_initializable(): void

--- a/spec/loophp/phptree/Importer/NikicPhpParserSpec.php
+++ b/spec/loophp/phptree/Importer/NikicPhpParserSpec.php
@@ -38,7 +38,7 @@ class NikicPhpParserSpec extends ObjectBehavior
         $this
             ->import($ast)
             ->count()
-            ->shouldReturn(582);
+            ->shouldReturn(575);
 
         $file = __DIR__ . '/../../../../tests/sample.php';
 
@@ -53,7 +53,7 @@ class NikicPhpParserSpec extends ObjectBehavior
         $this
             ->import($ast)
             ->count()
-            ->shouldReturn(109);
+            ->shouldReturn(105);
     }
 
     public function it_is_initializable(): void

--- a/spec/loophp/phptree/Node/TrieNodeSpec.php
+++ b/spec/loophp/phptree/Node/TrieNodeSpec.php
@@ -9,16 +9,16 @@ declare(strict_types=1);
 
 namespace spec\loophp\phptree\Node;
 
-use loophp\phptree\Node\KeyValueNode;
 use loophp\phptree\Node\TrieNode;
+use loophp\phptree\Node\ValueNode;
 
 class TrieNodeSpec extends NodeObjectBehavior
 {
     public function it_can_add_node(): void
     {
-        $this->beConstructedWith('key', 'value');
+        $this->beConstructedWith('value');
 
-        $nodes = [
+        $values = [
             1000,
             1001,
             10011,
@@ -33,21 +33,27 @@ class TrieNodeSpec extends NodeObjectBehavior
             'cba',
             'dcba',
             'edcba',
+            'zd',
+            'zde',
+            'zden',
+            'zdeně',
+            'zdeněk',
         ];
 
-        foreach ($nodes as $key => $value) {
-            $nodes[$key] = new KeyValueNode($key, (string) $value);
+        $nodes = [];
+        foreach ($values as $key => $value) {
+            $nodes[] = new ValueNode([$key, (string) $value]);
         }
 
         $this
             ->add(...$nodes)
             ->count()
-            ->shouldReturn(43);
+            ->shouldReturn(54);
     }
 
     public function it_is_initializable(): void
     {
-        $this->beConstructedWith('key', 'value');
+        $this->beConstructedWith('value');
         $this->shouldHaveType(TrieNode::class);
     }
 }

--- a/src/Importer/Text.php
+++ b/src/Importer/Text.php
@@ -48,16 +48,16 @@ final class Text implements ImporterInterface
     private function parse(string $subject): array
     {
         $result = [
-            'value' => substr($subject, 1, strpos($subject, '[', 1) - 1),
+            'value' => mb_substr($subject, 1, mb_strpos($subject, '[', 1) - 1),
             'children' => [],
         ];
 
-        if (false === $nextBracket = strpos($subject, '[', 1)) {
+        if (false === $nextBracket = mb_strpos($subject, '[', 1)) {
             return $result;
         }
 
         // Todo: Improve the regex.
-        preg_match_all('#[^\[\]]+|\[(?<nested>(?R)*)]#', substr($subject, $nextBracket, -1), $matches);
+        preg_match_all('#[^\[\]]+|\[(?<nested>(?R)*)]#u', mb_substr($subject, $nextBracket, -1), $matches);
 
         $result['children'] = array_map(
             static function (string $match): string {

--- a/src/Node/TrieNode.php
+++ b/src/Node/TrieNode.php
@@ -23,22 +23,22 @@ class TrieNode extends ValueNode
 
             $hash = hash('sha256', $key . $data);
 
-            $node = new self([$hash, substr($data, 0, 1)]);
+            $node = new self([$hash, mb_substr($data, 0, 1)]);
             $parent = $this->append($node);
 
-            $dataWithoutFirstLetter = substr($data, 1);
+            $dataWithoutFirstLetter = mb_substr($data, 1);
 
             if ('' < $dataWithoutFirstLetter) {
                 $parent->add(new self([$hash, $dataWithoutFirstLetter]));
             } else {
-                $nodes = [$node->getValue()];
+                $values = [$node->getValue()[1]];
 
-                /** @var KeyValueNodeInterface $ancestor */
+                /** @var ValueNode $ancestor */
                 foreach ($node->getAncestors() as $ancestor) {
-                    $nodes[] = $ancestor->getValue();
+                    $values[] = $ancestor->getValue()[1];
                 }
                 array_pop($nodes);
-                $node->append(new self([$hash, strrev(implode('', $nodes))]));
+                $node->append(new self([$hash, $this->mbStrRev(implode('', $values))]));
             }
         }
 
@@ -54,7 +54,7 @@ class TrieNode extends ValueNode
     {
         /** @var ValueNodeInterface $child */
         foreach ($this->children() as $child) {
-            if ($node->getValue() === $child->getValue()) {
+            if ($node->getValue()[1] === $child->getValue()[1]) {
                 return $child;
             }
         }
@@ -62,5 +62,12 @@ class TrieNode extends ValueNode
         parent::add($node);
 
         return $node;
+    }
+
+    private function mbStrRev(string $string): string
+    {
+        $chars = mb_str_split($string);
+
+        return implode('', array_reverse($chars));
     }
 }


### PR DESCRIPTION
I've added Unicode support to TrieNode and Text importer.
However since the commit https://github.com/loophp/phptree/commit/ed4ff23470313dcd43b1b8a26460ba78c1e59917, the project seems broken.
Do you plan to fix it and make a new release?